### PR TITLE
Use monokai for code theme in oled.json

### DIFF
--- a/themes/oled.json
+++ b/themes/oled.json
@@ -21,5 +21,5 @@
     "errorTextColor": "#e53935",
     "mentionHighlightBg": "#1C1C16",
     "mentionHighlightLink": "#039be5",
-    "codeTheme": "github"
+    "codeTheme": "monokai"
 }


### PR DESCRIPTION
The github theme has a white background which strains the eye if looking at a large code block. Monokai has a nice grey background which is easy to look at.